### PR TITLE
child threads return to main process after ending

### DIFF
--- a/server.py
+++ b/server.py
@@ -48,6 +48,7 @@ def startConneciton():
         thread = threading.Thread(target=handleClient, args=(conn, address))
         thread.start()
         print(f"[ACTIVE CONNECTIONS] {threading.activeCount() - 1}")
+        thread.join()
 
 
 print(f"[STARTING] Server is starting on PORT {PORT}")


### PR DESCRIPTION
Child threads now return to main process after ending as opposed to hanging previously